### PR TITLE
Create spv proof for transaction

### DIFF
--- a/bridge-circuit-host/src/bridge_circuit_host.rs
+++ b/bridge-circuit-host/src/bridge_circuit_host.rs
@@ -347,6 +347,25 @@ pub fn create_spv(
         ));
     }
 
+    if (payment_block_height - genesis_block_height) as usize >= block_hash_bytes.len() {
+        return Err(eyre!(
+            "Block hash bytes length ({}) is insufficient for payment block height {} given genesis block height {}",
+            block_hash_bytes.len(),
+            payment_block_height,
+            genesis_block_height
+        ));
+    }
+    // Ensure the supplied block hash matches the payment block's actual hash
+    let expected_block_hash = bitcoin::hashes::Hash::to_byte_array(&payment_block.header.block_hash());
+    let mmr_leaf_hash = block_hash_bytes[(payment_block_height - genesis_block_height) as usize];
+    if expected_block_hash != mmr_leaf_hash {
+        return Err(eyre!(
+            "Mismatch between payment block hash and the corresponding hash in block_hash_bytes: expected {:?}, found {:?}",
+            expected_block_hash,
+            mmr_leaf_hash
+        ));
+    }
+
     let mut mmr_native = MMRNative::new();
     for block_hash in block_hash_bytes {
         mmr_native.append(*block_hash);


### PR DESCRIPTION
# Description

Adds pre-checks to `create_spv` to validate the `block_hash_bytes` input. This ensures the provided block hash list is sufficient in length and contains the correct hash for the `payment_block` at its expected position, preventing the generation of invalid SPV proofs.

## Linked Issues

- Closes # (issue, if applicable)
- Related to # (issue)

## Testing

Input validation checks were added. Unit tests should be added to cover cases where `block_hash_bytes` is too short or contains a mismatched hash for the `payment_block`.

## Docs

No changes to documented interfaces.

---
<a href="https://cursor.com/background-agent?bcId=bc-01868df3-d09b-43f8-93b8-1130bd7940c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01868df3-d09b-43f8-93b8-1130bd7940c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

